### PR TITLE
Fix table metadata parsing to properly align metadata of ENUM and SET types

### DIFF
--- a/src/event/table_map/table_metadata.rs
+++ b/src/event/table_map/table_metadata.rs
@@ -75,12 +75,16 @@ impl ColumnMetadata {
 }
 
 impl TableMetadata {
-    pub fn parse(cursor: &mut Cursor<&Vec<u8>>, column_types: &[u8]) -> Result<Self, BinlogError> {
+    pub fn parse(
+        cursor: &mut Cursor<&Vec<u8>>,
+        column_types: &[u8],
+        column_metas: &[u16],
+    ) -> Result<Self, BinlogError> {
         // Initialize columns with default values
         let mut columns: Vec<ColumnMetadata> = (0..column_types.len())
             .map(|_| ColumnMetadata::new())
             .collect();
-        
+
         let mut default_charset = None;
         let mut enum_and_set_default_charset = None;
 
@@ -107,10 +111,15 @@ impl TableMetadata {
                     parse_column_names(&mut columns, &mut buffer)?;
                 }
                 MetadataType::SetStrValue => {
-                    parse_set_string_values(&mut columns, &mut buffer)?;
+                    parse_set_string_values(&mut columns, &mut buffer, column_types, column_metas)?;
                 }
                 MetadataType::EnumStrValue => {
-                    parse_enum_string_values(&mut columns, &mut buffer)?;
+                    parse_enum_string_values(
+                        &mut columns,
+                        &mut buffer,
+                        column_types,
+                        column_metas,
+                    )?;
                 }
                 MetadataType::GeometryType => {
                     parse_geometry_types(&mut columns, &mut buffer)?;
@@ -141,7 +150,6 @@ impl TableMetadata {
         })
     }
 }
-
 
 fn parse_default_charset(cursor: &mut Cursor<&Vec<u8>>) -> Result<DefaultCharset, BinlogError> {
     let default_collation = cursor.read_packed_number()?;
@@ -180,12 +188,19 @@ pub(crate) fn read_bitmap_reverted(
 
 // Helper functions for applying metadata to columns
 
-fn read_signedness_bitmap(cursor: &mut Cursor<&Vec<u8>>, column_types: &[u8]) -> Result<Vec<bool>, BinlogError> {
+fn read_signedness_bitmap(
+    cursor: &mut Cursor<&Vec<u8>>,
+    column_types: &[u8],
+) -> Result<Vec<bool>, BinlogError> {
     let count = get_numeric_column_count(column_types)?;
     read_bitmap_reverted(cursor, count)
 }
 
-fn apply_signedness_to_columns(columns: &mut [ColumnMetadata], column_types: &[u8], signedness_values: &[bool]) {
+fn apply_signedness_to_columns(
+    columns: &mut [ColumnMetadata],
+    column_types: &[u8],
+    signedness_values: &[bool],
+) {
     let mut signedness_index = 0;
     for (i, &column_type_code) in column_types.iter().enumerate() {
         let column_type = ColumnType::from_code(column_type_code);
@@ -198,7 +213,10 @@ fn apply_signedness_to_columns(columns: &mut [ColumnMetadata], column_types: &[u
     }
 }
 
-fn parse_column_charsets(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Vec<u8>>) -> Result<(), BinlogError> {
+fn parse_column_charsets(
+    columns: &mut [ColumnMetadata],
+    cursor: &mut Cursor<&Vec<u8>>,
+) -> Result<(), BinlogError> {
     let mut index = 0;
     while cursor.available() > 0 && index < columns.len() {
         let charset = cursor.read_packed_number()? as u32;
@@ -208,7 +226,10 @@ fn parse_column_charsets(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Ve
     Ok(())
 }
 
-fn parse_column_names(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Vec<u8>>) -> Result<(), BinlogError> {
+fn parse_column_names(
+    columns: &mut [ColumnMetadata],
+    cursor: &mut Cursor<&Vec<u8>>,
+) -> Result<(), BinlogError> {
     let mut index = 0;
     while cursor.available() > 0 && index < columns.len() {
         let length = cursor.read_packed_number()?;
@@ -219,9 +240,15 @@ fn parse_column_names(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Vec<u
     Ok(())
 }
 
-fn parse_set_string_values(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Vec<u8>>) -> Result<(), BinlogError> {
-    let mut index = 0;
-    while cursor.available() > 0 && index < columns.len() {
+fn parse_set_string_values(
+    columns: &mut [ColumnMetadata],
+    cursor: &mut Cursor<&Vec<u8>>,
+    column_types: &[u8],
+    column_metas: &[u16],
+) -> Result<(), BinlogError> {
+    let mut set_column_index = 0;
+
+    while cursor.available() > 0 {
         let length = cursor.read_packed_number()?;
         let mut values = Vec::new();
         for _ in 0..length {
@@ -229,15 +256,33 @@ fn parse_set_string_values(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&
             let value = cursor.read_string(str_length)?;
             values.push(value);
         }
-        columns[index].set_string_values = Some(values);
-        index += 1;
+
+        // Find the set_column_index-th SET column and apply values to it
+        // SetStrValue metadata is provided in the order of columns that are actual SETs
+        let mut current_set_index = 0;
+        for i in 0..column_types.len() {
+            if is_set_column(column_types[i], column_metas[i]) {
+                if current_set_index == set_column_index {
+                    columns[i].set_string_values = Some(values);
+                    break;
+                }
+                current_set_index += 1;
+            }
+        }
+        set_column_index += 1;
     }
     Ok(())
 }
 
-fn parse_enum_string_values(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Vec<u8>>) -> Result<(), BinlogError> {
-    let mut index = 0;
-    while cursor.available() > 0 && index < columns.len() {
+fn parse_enum_string_values(
+    columns: &mut [ColumnMetadata],
+    cursor: &mut Cursor<&Vec<u8>>,
+    column_types: &[u8],
+    column_metas: &[u16],
+) -> Result<(), BinlogError> {
+    let mut enum_column_index = 0;
+
+    while cursor.available() > 0 {
         let length = cursor.read_packed_number()?;
         let mut values = Vec::new();
         for _ in 0..length {
@@ -245,13 +290,28 @@ fn parse_enum_string_values(columns: &mut [ColumnMetadata], cursor: &mut Cursor<
             let value = cursor.read_string(str_length)?;
             values.push(value);
         }
-        columns[index].enum_string_values = Some(values);
-        index += 1;
+
+        // Find the enum_column_index-th ENUM column and apply values to it
+        // EnumStrValue metadata is provided in the order of columns that are actual ENUMs
+        let mut current_enum_index = 0;
+        for i in 0..column_types.len() {
+            if is_enum_column(column_types[i], column_metas[i]) {
+                if current_enum_index == enum_column_index {
+                    columns[i].enum_string_values = Some(values);
+                    break;
+                }
+                current_enum_index += 1;
+            }
+        }
+        enum_column_index += 1;
     }
     Ok(())
 }
 
-fn parse_geometry_types(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Vec<u8>>) -> Result<(), BinlogError> {
+fn parse_geometry_types(
+    columns: &mut [ColumnMetadata],
+    cursor: &mut Cursor<&Vec<u8>>,
+) -> Result<(), BinlogError> {
     let mut index = 0;
     while cursor.available() > 0 && index < columns.len() {
         let geometry_type = cursor.read_packed_number()? as u32;
@@ -261,7 +321,10 @@ fn parse_geometry_types(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Vec
     Ok(())
 }
 
-fn parse_simple_primary_keys(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Vec<u8>>) -> Result<(), BinlogError> {
+fn parse_simple_primary_keys(
+    columns: &mut [ColumnMetadata],
+    cursor: &mut Cursor<&Vec<u8>>,
+) -> Result<(), BinlogError> {
     while cursor.available() > 0 {
         let pk_column = cursor.read_packed_number()?;
         if let Some(column) = columns.get_mut(pk_column) {
@@ -271,7 +334,10 @@ fn parse_simple_primary_keys(columns: &mut [ColumnMetadata], cursor: &mut Cursor
     Ok(())
 }
 
-fn parse_primary_key_prefixes(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Vec<u8>>) -> Result<(), BinlogError> {
+fn parse_primary_key_prefixes(
+    columns: &mut [ColumnMetadata],
+    cursor: &mut Cursor<&Vec<u8>>,
+) -> Result<(), BinlogError> {
     while cursor.available() > 0 {
         let column_index = cursor.read_packed_number()?;
         let prefix_length = cursor.read_packed_number()? as u32;
@@ -282,7 +348,10 @@ fn parse_primary_key_prefixes(columns: &mut [ColumnMetadata], cursor: &mut Curso
     Ok(())
 }
 
-fn parse_enum_set_charsets(columns: &mut [ColumnMetadata], cursor: &mut Cursor<&Vec<u8>>) -> Result<(), BinlogError> {
+fn parse_enum_set_charsets(
+    columns: &mut [ColumnMetadata],
+    cursor: &mut Cursor<&Vec<u8>>,
+) -> Result<(), BinlogError> {
     let mut index = 0;
     while cursor.available() > 0 && index < columns.len() {
         let charset = cursor.read_packed_number()? as u32;
@@ -299,16 +368,39 @@ fn apply_column_visibility(columns: &mut [ColumnMetadata], visibility: &[bool]) 
 }
 
 fn is_numeric_type(column_type: ColumnType) -> bool {
-    matches!(column_type,
+    matches!(
+        column_type,
         ColumnType::Tiny
-        | ColumnType::Short
-        | ColumnType::Int24
-        | ColumnType::Long
-        | ColumnType::LongLong
-        | ColumnType::Float
-        | ColumnType::Double
-        | ColumnType::NewDecimal
+            | ColumnType::Short
+            | ColumnType::Int24
+            | ColumnType::Long
+            | ColumnType::LongLong
+            | ColumnType::Float
+            | ColumnType::Double
+            | ColumnType::NewDecimal
     )
+}
+
+fn is_enum_column(column_type_code: u8, column_meta: u16) -> bool {
+    if column_type_code == ColumnType::String as u8 {
+        if let Ok((real_column_type, _)) =
+            ColumnType::parse_string_column_meta(column_meta, column_type_code)
+        {
+            return real_column_type == ColumnType::Enum as u8;
+        }
+    }
+    false
+}
+
+fn is_set_column(column_type_code: u8, column_meta: u16) -> bool {
+    if column_type_code == ColumnType::String as u8 {
+        if let Ok((real_column_type, _)) =
+            ColumnType::parse_string_column_meta(column_meta, column_type_code)
+        {
+            return real_column_type == ColumnType::Set as u8;
+        }
+    }
+    false
 }
 
 pub(crate) fn get_numeric_column_count(column_types: &[u8]) -> Result<usize, BinlogError> {
@@ -339,6 +431,18 @@ mod tests {
         ]
     }
 
+    fn create_test_column_metas() -> Vec<u16> {
+        vec![
+            0, // TINY - no metadata
+            0, // LONG - no metadata
+            0, // FLOAT - no metadata
+            0, // DOUBLE - no metadata
+            0, // NEWDECIMAL - no metadata
+            0, // VAR_STRING - no metadata
+            0, // STRING - no metadata
+        ]
+    }
+
     #[test]
     fn test_get_numeric_column_count() {
         let column_types = create_test_column_types();
@@ -357,16 +461,17 @@ mod tests {
         ];
 
         let column_types = create_test_column_types();
+        let column_metas = create_test_column_metas();
         let mut cursor = Cursor::new(&test_data);
-        let result = TableMetadata::parse(&mut cursor, &column_types).unwrap();
+        let result = TableMetadata::parse(&mut cursor, &column_types, &column_metas).unwrap();
 
         assert_eq!(result.columns.len(), 7); // Total columns
 
         // Check signedness for numeric columns only
-        assert_eq!(result.columns[0].is_signed, Some(true));  // TINY - bit 7 -> signed
-        assert_eq!(result.columns[1].is_signed, Some(true));  // LONG - bit 6 -> signed
+        assert_eq!(result.columns[0].is_signed, Some(true)); // TINY - bit 7 -> signed
+        assert_eq!(result.columns[1].is_signed, Some(true)); // LONG - bit 6 -> signed
         assert_eq!(result.columns[2].is_signed, Some(false)); // FLOAT - bit 5 -> unsigned
-        assert_eq!(result.columns[3].is_signed, Some(true));  // DOUBLE - bit 4 -> signed
+        assert_eq!(result.columns[3].is_signed, Some(true)); // DOUBLE - bit 4 -> signed
         assert_eq!(result.columns[4].is_signed, Some(false)); // NEWDECIMAL - bit 3 -> unsigned
 
         // Non-numeric columns should not have signedness
@@ -384,14 +489,15 @@ mod tests {
         ];
 
         let column_types = create_test_column_types();
+        let column_metas = create_test_column_metas();
         let mut cursor = Cursor::new(&test_data);
-        let result = TableMetadata::parse(&mut cursor, &column_types).unwrap();
+        let result = TableMetadata::parse(&mut cursor, &column_types, &column_metas).unwrap();
 
         assert_eq!(result.columns.len(), 7);
-        
+
         // Only first column should have a name
         assert_eq!(result.columns[0].column_name, Some("id".to_string()));
-        
+
         // Other columns should not have names
         for i in 1..7 {
             assert_eq!(result.columns[i].column_name, None);
@@ -408,8 +514,9 @@ mod tests {
         ];
 
         let column_types = create_test_column_types();
+        let column_metas = create_test_column_metas();
         let mut cursor = Cursor::new(&test_data);
-        let result = TableMetadata::parse(&mut cursor, &column_types).unwrap();
+        let result = TableMetadata::parse(&mut cursor, &column_types, &column_metas).unwrap();
 
         assert!(result.default_charset.is_some());
         let default_charset = result.default_charset.unwrap();
@@ -427,22 +534,37 @@ mod tests {
             5, b's', b'm', b'a', b'l', b'l', // "small"
         ];
 
-        let column_types = create_test_column_types();
-        let mut cursor = Cursor::new(&test_data);
-        let result = TableMetadata::parse(&mut cursor, &column_types).unwrap();
+        // Create column types with an actual ENUM column (String type with ENUM metadata)
+        let column_types = vec![
+            1,   // MYSQL_TYPE_TINY (numeric, index 0)
+            254, // MYSQL_TYPE_STRING - this will be decoded as ENUM (index 1)
+            3,   // MYSQL_TYPE_LONG (numeric, index 2)
+        ];
 
-        assert_eq!(result.columns.len(), 7);
-        
-        // Only first column should have enum values
-        assert!(result.columns[0].enum_string_values.is_some());
-        let enum_values = result.columns[0].enum_string_values.as_ref().unwrap();
+        // Create column metadata with ENUM encoding for the String column
+        // For ENUM: high byte = 247 (ColumnType::Enum), low byte = number of values
+        let column_metas = vec![
+            0,              // TINY - no metadata
+            (247 << 8) | 1, // STRING with ENUM metadata (247 = ENUM type, 1 value)
+            0,              // LONG - no metadata
+        ];
+
+        let mut cursor = Cursor::new(&test_data);
+        let result = TableMetadata::parse(&mut cursor, &column_types, &column_metas).unwrap();
+
+        assert_eq!(result.columns.len(), 3);
+
+        // First column (TINY) should not have enum values
+        assert!(result.columns[0].enum_string_values.is_none());
+
+        // Second column (ENUM) should have enum values
+        assert!(result.columns[1].enum_string_values.is_some());
+        let enum_values = result.columns[1].enum_string_values.as_ref().unwrap();
         assert_eq!(enum_values.len(), 1);
         assert_eq!(enum_values[0], "small");
 
-        // Other columns should not have enum values
-        for i in 1..7 {
-            assert_eq!(result.columns[i].enum_string_values, None);
-        }
+        // Third column (LONG) should not have enum values
+        assert!(result.columns[2].enum_string_values.is_none());
     }
 
     #[test]
@@ -460,15 +582,16 @@ mod tests {
         ];
 
         let column_types = create_test_column_types();
+        let column_metas = create_test_column_metas();
         let mut cursor = Cursor::new(&test_data);
-        let result = TableMetadata::parse(&mut cursor, &column_types).unwrap();
+        let result = TableMetadata::parse(&mut cursor, &column_types, &column_metas).unwrap();
 
         assert_eq!(result.columns.len(), 7);
 
         // Check signedness was applied
-        assert_eq!(result.columns[0].is_signed, Some(true));  // TINY - bit 7 set
+        assert_eq!(result.columns[0].is_signed, Some(true)); // TINY - bit 7 set
         assert_eq!(result.columns[1].is_signed, Some(false)); // LONG - bit 6 not set
-        assert_eq!(result.columns[2].is_signed, Some(true));  // FLOAT - bit 5 set
+        assert_eq!(result.columns[2].is_signed, Some(true)); // FLOAT - bit 5 set
 
         // Check column name was applied
         assert_eq!(result.columns[0].column_name, Some("id".to_string()));
@@ -479,14 +602,15 @@ mod tests {
     fn test_parse_empty_metadata() {
         let test_data = vec![];
         let column_types = create_test_column_types();
+        let column_metas = create_test_column_metas();
         let mut cursor = Cursor::new(&test_data);
-        let result = TableMetadata::parse(&mut cursor, &column_types).unwrap();
+        let result = TableMetadata::parse(&mut cursor, &column_types, &column_metas).unwrap();
 
         // Should have all columns initialized but with no metadata
         assert_eq!(result.columns.len(), 7);
         assert!(result.default_charset.is_none());
         assert!(result.enum_and_set_default_charset.is_none());
-        
+
         // All column metadata should be None
         for column in &result.columns {
             assert_eq!(column.column_name, None);
@@ -510,10 +634,10 @@ mod tests {
         let result = read_bitmap_reverted(&mut cursor, 5).unwrap();
 
         assert_eq!(result.len(), 5);
-        assert_eq!(result[0], true);  // bit 7
-        assert_eq!(result[1], true);  // bit 6
+        assert_eq!(result[0], true); // bit 7
+        assert_eq!(result[1], true); // bit 6
         assert_eq!(result[2], false); // bit 5
-        assert_eq!(result[3], true);  // bit 4
+        assert_eq!(result[3], true); // bit 4
         assert_eq!(result[4], false); // bit 3
     }
 

--- a/src/event/table_map_event.rs
+++ b/src/event/table_map_event.rs
@@ -4,8 +4,8 @@ use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    binlog_error::BinlogError, column::column_type::ColumnType, ext::cursor_ext::CursorExt,
-    event::table_map::table_metadata::TableMetadata,
+    binlog_error::BinlogError, column::column_type::ColumnType,
+    event::table_map::table_metadata::TableMetadata, ext::cursor_ext::CursorExt,
 };
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -56,7 +56,7 @@ impl TableMapEvent {
         // table_metadata (MySQL 8.0.1+ and MariaDB 10.5+)
         let mut table_metadata = None;
         if cursor.available() > 0 {
-            table_metadata = Some(TableMetadata::parse(cursor, &column_types)?);
+            table_metadata = Some(TableMetadata::parse(cursor, &column_types, &column_metas)?);
         }
 
         Ok(Self {

--- a/tests/data_type_tests/enum_tests.rs
+++ b/tests/data_type_tests/enum_tests.rs
@@ -18,6 +18,137 @@ mod test {
         run_and_check(col_type, &values, &check_values);
     }
 
+    #[test]
+    #[serial]
+    fn test_enum_metadata_parsing() {
+        let prepare_sqls = vec![
+            "DROP DATABASE IF EXISTS test_enum_metadata".to_string(),
+            "CREATE DATABASE test_enum_metadata".to_string(),
+        ];
+
+        let test_sqls = vec![
+            // Create a table with ENUM columns that will generate metadata
+            r#"CREATE TABLE test_enum_metadata.enum_metadata_test (
+                id INT PRIMARY KEY,
+                name VARCHAR(100),
+                size ENUM('x-small', 'small', 'medium', 'large', 'x-large'),
+                price DECIMAL(10,2),
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                status ENUM('active', 'inactive', 'pending', 'archived'),
+                description TEXT
+            )"#.to_string(),
+            // Insert data to trigger table map events
+            "INSERT INTO test_enum_metadata.enum_metadata_test (id, name, size, price, status, description) VALUES (1, 'Test Item', 'small', 19.99, 'active', 'A test description')".to_string(),
+        ];
+
+        let mut runner = TestRunner::new();
+        runner.execute_sqls_and_get_binlogs(&prepare_sqls, &test_sqls);
+
+        // Verify we got both insert events and table map events
+        assert!(
+            !runner.insert_events.is_empty(),
+            "Should have received WriteRowsEvent"
+        );
+        assert!(
+            !runner.table_map_events.is_empty(),
+            "Should have received TableMapEvent"
+        );
+
+        // Find the table map event for our test table
+        let table_event = runner
+            .table_map_events
+            .iter()
+            .find(|event| {
+                event.database_name == "test_enum_metadata"
+                    && event.table_name == "enum_metadata_test"
+            })
+            .expect("Should find TableMapEvent for enum test table");
+
+        // Verify we have metadata
+        assert!(
+            table_event.table_metadata.is_some(),
+            "Table should have metadata"
+        );
+        let metadata = table_event.table_metadata.as_ref().unwrap();
+
+        // Verify we have the expected number of columns
+        assert_eq!(metadata.columns.len(), 7, "Should have 7 columns");
+
+        // Verify that enum metadata is parsed and applied to the correct ENUM columns
+        // Column 0: id (INT) - should not have enum values
+        // Column 1: name (VARCHAR) - should not have enum values
+        // Column 2: size (ENUM) - should have the size enum values
+        // Column 3: price (DECIMAL) - should not have enum values
+        // Column 4: created_at (TIMESTAMP) - should not have enum values
+        // Column 5: status (ENUM) - should have the status enum values
+        // Column 6: description (TEXT) - should not have enum values
+
+        // Check that enum string values are applied to the correct columns
+        assert!(
+            metadata.columns[0].enum_string_values.is_none(),
+            "Column 0 (id) should not have enum string values"
+        );
+        assert!(
+            metadata.columns[1].enum_string_values.is_none(),
+            "Column 1 (name) should not have enum string values"
+        );
+        assert!(
+            metadata.columns[2].enum_string_values.is_some(),
+            "Column 2 (size) should have enum string values"
+        );
+        assert!(
+            metadata.columns[3].enum_string_values.is_none(),
+            "Column 3 (price) should not have enum string values"
+        );
+        assert!(
+            metadata.columns[4].enum_string_values.is_none(),
+            "Column 4 (created_at) should not have enum string values"
+        );
+        assert!(
+            metadata.columns[5].enum_string_values.is_some(),
+            "Column 5 (status) should have enum string values"
+        );
+        assert!(
+            metadata.columns[6].enum_string_values.is_none(),
+            "Column 6 (description) should not have enum string values"
+        );
+
+        // Verify the size enum values are in column 2
+        let size_enum_values = metadata.columns[2].enum_string_values.as_ref().unwrap();
+        assert_eq!(size_enum_values.len(), 5, "Size enum should have 5 values");
+        assert_eq!(size_enum_values[0], "x-small");
+        assert_eq!(size_enum_values[1], "small");
+        assert_eq!(size_enum_values[2], "medium");
+        assert_eq!(size_enum_values[3], "large");
+        assert_eq!(size_enum_values[4], "x-large");
+
+        // Verify the status enum values are in column 5
+        let status_enum_values = metadata.columns[5].enum_string_values.as_ref().unwrap();
+        assert_eq!(
+            status_enum_values.len(),
+            4,
+            "Status enum should have 4 values"
+        );
+        assert_eq!(status_enum_values[0], "active");
+        assert_eq!(status_enum_values[1], "inactive");
+        assert_eq!(status_enum_values[2], "pending");
+        assert_eq!(status_enum_values[3], "archived");
+
+        // Verify the insert event data
+        let insert_event = &runner.insert_events[0];
+        let row = &insert_event.rows[0];
+        assert_eq!(
+            row.column_values[2],
+            ColumnValue::Enum(2),
+            "Should have 'small' enum value (index 2)"
+        );
+        assert_eq!(
+            row.column_values[5],
+            ColumnValue::Enum(1),
+            "Should have 'active' enum value (index 1)"
+        );
+    }
+
     fn run_and_check(col_type: &str, values: &Vec<&str>, check_values: &Vec<u32>) {
         let runner = TestRunner::run_one_col_test(col_type, values, &vec![]);
         for i in 0..check_values.len() {

--- a/tests/data_type_tests/set_tests.rs
+++ b/tests/data_type_tests/set_tests.rs
@@ -34,6 +34,137 @@ mod test {
         run_and_check(col_type, &values, &check_values);
     }
 
+    #[test]
+    #[serial]
+    fn test_set_metadata_parsing() {
+        let prepare_sqls = vec![
+            "DROP DATABASE IF EXISTS test_set_metadata".to_string(),
+            "CREATE DATABASE test_set_metadata".to_string(),
+        ];
+
+        let test_sqls = vec![
+            // Create a table with SET columns that will generate metadata
+            r#"CREATE TABLE test_set_metadata.set_metadata_test (
+                id INT PRIMARY KEY,
+                name VARCHAR(100),
+                permissions SET('read', 'write', 'execute', 'delete'),
+                priority INT,
+                created_by VARCHAR(50),
+                flags SET('urgent', 'priority', 'confidential'),
+                updated_at DATETIME
+            )"#.to_string(),
+            // Insert data to trigger table map events
+            "INSERT INTO test_set_metadata.set_metadata_test (id, name, permissions, priority, created_by, flags, updated_at) VALUES (1, 'Test Task', 'read,write', 10, 'admin', 'urgent', '2023-01-01 10:00:00')".to_string(),
+        ];
+
+        let mut runner = TestRunner::new();
+        runner.execute_sqls_and_get_binlogs(&prepare_sqls, &test_sqls);
+
+        // Verify we got both insert events and table map events
+        assert!(
+            !runner.insert_events.is_empty(),
+            "Should have received WriteRowsEvent"
+        );
+        assert!(
+            !runner.table_map_events.is_empty(),
+            "Should have received TableMapEvent"
+        );
+
+        // Find the table map event for our test table
+        let table_event = runner
+            .table_map_events
+            .iter()
+            .find(|event| {
+                event.database_name == "test_set_metadata"
+                    && event.table_name == "set_metadata_test"
+            })
+            .expect("Should find TableMapEvent for set test table");
+
+        // Verify we have metadata
+        assert!(
+            table_event.table_metadata.is_some(),
+            "Table should have metadata"
+        );
+        let metadata = table_event.table_metadata.as_ref().unwrap();
+
+        // Verify we have the expected number of columns
+        assert_eq!(metadata.columns.len(), 7, "Should have 7 columns");
+
+        // Verify that set metadata is parsed and applied to the correct SET columns
+        // Column 0: id (INT) - should not have set values
+        // Column 1: name (VARCHAR) - should not have set values
+        // Column 2: permissions (SET) - should have the permissions set values
+        // Column 3: priority (INT) - should not have set values
+        // Column 4: created_by (VARCHAR) - should not have set values
+        // Column 5: flags (SET) - should have the flags set values
+        // Column 6: updated_at (DATETIME) - should not have set values
+
+        // Check that set string values are applied to the correct columns
+        assert!(
+            metadata.columns[0].set_string_values.is_none(),
+            "Column 0 (id) should not have set string values"
+        );
+        assert!(
+            metadata.columns[1].set_string_values.is_none(),
+            "Column 1 (name) should not have set string values"
+        );
+        assert!(
+            metadata.columns[2].set_string_values.is_some(),
+            "Column 2 (permissions) should have set string values"
+        );
+        assert!(
+            metadata.columns[3].set_string_values.is_none(),
+            "Column 3 (priority) should not have set string values"
+        );
+        assert!(
+            metadata.columns[4].set_string_values.is_none(),
+            "Column 4 (created_by) should not have set string values"
+        );
+        assert!(
+            metadata.columns[5].set_string_values.is_some(),
+            "Column 5 (flags) should have set string values"
+        );
+        assert!(
+            metadata.columns[6].set_string_values.is_none(),
+            "Column 6 (updated_at) should not have set string values"
+        );
+
+        // Verify the permissions set values are in column 2
+        let permissions_set_values = metadata.columns[2].set_string_values.as_ref().unwrap();
+        assert_eq!(
+            permissions_set_values.len(),
+            4,
+            "Permissions set should have 4 values"
+        );
+        assert_eq!(permissions_set_values[0], "read");
+        assert_eq!(permissions_set_values[1], "write");
+        assert_eq!(permissions_set_values[2], "execute");
+        assert_eq!(permissions_set_values[3], "delete");
+
+        // Verify the flags set values are in column 5
+        let flags_set_values = metadata.columns[5].set_string_values.as_ref().unwrap();
+        assert_eq!(flags_set_values.len(), 3, "Flags set should have 3 values");
+        assert_eq!(flags_set_values[0], "urgent");
+        assert_eq!(flags_set_values[1], "priority");
+        assert_eq!(flags_set_values[2], "confidential");
+
+        // Verify the insert event data
+        let insert_event = &runner.insert_events[0];
+        let row = &insert_event.rows[0];
+        // 'read,write' = bit 0 (read) + bit 1 (write) = 1 + 2 = 3
+        assert_eq!(
+            row.column_values[2],
+            ColumnValue::Set(3),
+            "Should have 'read,write' set value (bits 0+1 = 3)"
+        );
+        // 'urgent' = bit 0 = 1
+        assert_eq!(
+            row.column_values[5],
+            ColumnValue::Set(1),
+            "Should have 'urgent' set value (bit 0 = 1)"
+        );
+    }
+
     fn run_and_check(col_type: &str, values: &Vec<&str>, check_values: &Vec<u64>) {
         let runner = TestRunner::run_one_col_test(col_type, values, &vec![]);
         for i in 0..check_values.len() {

--- a/tests/dml_tests/delete_tests.rs
+++ b/tests/dml_tests/delete_tests.rs
@@ -28,14 +28,24 @@ mod test {
         assert_eq!(runner.delete_events[0].rows.len(), 5);
 
         // Verify table map events are generated for delete operations
-        assert!(!runner.table_map_events.is_empty(), "Should have table map events for delete operations");
-        
+        assert!(
+            !runner.table_map_events.is_empty(),
+            "Should have table map events for delete operations"
+        );
+
         // Verify delete events reference the correct table ID
-        let table_event = runner.table_map_events.iter()
-            .find(|event| event.database_name == runner.default_db && event.table_name == runner.default_tb)
+        let table_event = runner
+            .table_map_events
+            .iter()
+            .find(|event| {
+                event.database_name == runner.default_db && event.table_name == runner.default_tb
+            })
             .expect("Should find table map event for default test table");
-        
-        assert_eq!(runner.delete_events[0].table_id, table_event.table_id, "Delete events should reference the correct table");
+
+        assert_eq!(
+            runner.delete_events[0].table_id, table_event.table_id,
+            "Delete events should reference the correct table"
+        );
 
         // row 0
         Mock::default_check_values(

--- a/tests/dml_tests/insert_tests.rs
+++ b/tests/dml_tests/insert_tests.rs
@@ -28,16 +28,29 @@ mod test {
         assert_eq!(runner.insert_events[1].rows.len(), 1);
 
         // Verify table map events are generated for DML operations
-        assert!(!runner.table_map_events.is_empty(), "Should have table map events for DML operations");
-        
+        assert!(
+            !runner.table_map_events.is_empty(),
+            "Should have table map events for DML operations"
+        );
+
         // Verify table map events reference the correct table
-        let table_event = runner.table_map_events.iter()
-            .find(|event| event.database_name == runner.default_db && event.table_name == runner.default_tb)
+        let table_event = runner
+            .table_map_events
+            .iter()
+            .find(|event| {
+                event.database_name == runner.default_db && event.table_name == runner.default_tb
+            })
             .expect("Should find table map event for default test table");
-        
+
         // Verify insert events reference the same table ID
-        assert_eq!(runner.insert_events[0].table_id, table_event.table_id, "Insert events should reference the correct table");
-        assert_eq!(runner.insert_events[1].table_id, table_event.table_id, "Insert events should reference the correct table");
+        assert_eq!(
+            runner.insert_events[0].table_id, table_event.table_id,
+            "Insert events should reference the correct table"
+        );
+        assert_eq!(
+            runner.insert_events[1].table_id, table_event.table_id,
+            "Insert events should reference the correct table"
+        );
 
         Mock::default_check_values(
             &runner.insert_events[0].rows[0],
@@ -225,12 +238,23 @@ mod test {
         runner.execute_sqls_and_get_binlogs(&prepare_sqls, &test_sqls);
 
         // Verify we got both insert events and table map events
-        assert!(!runner.insert_events.is_empty(), "Should have received WriteRowsEvent");
-        assert!(!runner.table_map_events.is_empty(), "Should have received TableMapEvent");
+        assert!(
+            !runner.insert_events.is_empty(),
+            "Should have received WriteRowsEvent"
+        );
+        assert!(
+            !runner.table_map_events.is_empty(),
+            "Should have received TableMapEvent"
+        );
 
         // Find the table map event for our test table
-        let table_event = runner.table_map_events.iter()
-            .find(|event| event.database_name == "test_table_map_metadata" && event.table_name == "metadata_test")
+        let table_event = runner
+            .table_map_events
+            .iter()
+            .find(|event| {
+                event.database_name == "test_table_map_metadata"
+                    && event.table_name == "metadata_test"
+            })
             .expect("Should find TableMapEvent for our test table");
 
         // Verify basic table info
@@ -238,7 +262,10 @@ mod test {
         assert_eq!(table_event.table_name, "metadata_test");
 
         // Verify we have metadata
-        assert!(table_event.table_metadata.is_some(), "Table should have metadata");
+        assert!(
+            table_event.table_metadata.is_some(),
+            "Table should have metadata"
+        );
         let metadata = table_event.table_metadata.as_ref().unwrap();
 
         // Verify we have the expected number of columns
@@ -256,19 +283,34 @@ mod test {
         }
 
         // Verify signedness metadata is present for numeric columns
-        assert!(metadata.columns[0].is_signed.is_some(), "INT column should have signedness metadata");
-        assert!(metadata.columns[2].is_signed.is_some(), "TINYINT column should have signedness metadata");
-        assert!(metadata.columns[3].is_signed.is_some(), "DECIMAL column should have signedness metadata");
+        assert!(
+            metadata.columns[0].is_signed.is_some(),
+            "INT column should have signedness metadata"
+        );
+        assert!(
+            metadata.columns[2].is_signed.is_some(),
+            "TINYINT column should have signedness metadata"
+        );
+        assert!(
+            metadata.columns[3].is_signed.is_some(),
+            "DECIMAL column should have signedness metadata"
+        );
 
         // Verify charset metadata exists for string columns (when available)
         if let Some(charset_collation) = metadata.columns[1].charset_collation {
-            assert!(charset_collation > 0, "String column should have valid charset collation");
+            assert!(
+                charset_collation > 0,
+                "String column should have valid charset collation"
+            );
         }
 
         // Verify the corresponding insert event references the same table
         let insert_event = &runner.insert_events[0];
-        assert_eq!(insert_event.table_id, table_event.table_id, "Insert event should reference the same table as table map event");
-        
+        assert_eq!(
+            insert_event.table_id, table_event.table_id,
+            "Insert event should reference the same table as table map event"
+        );
+
         // Verify we have the inserted row data
         assert_eq!(insert_event.rows.len(), 1, "Should have one inserted row");
         let row = &insert_event.rows[0];

--- a/tests/dml_tests/update_tests.rs
+++ b/tests/dml_tests/update_tests.rs
@@ -37,15 +37,25 @@ mod test {
         assert_eq!(runner.update_events.len(), 4);
 
         // Verify table map events are generated for update operations
-        assert!(!runner.table_map_events.is_empty(), "Should have table map events for update operations");
-        
+        assert!(
+            !runner.table_map_events.is_empty(),
+            "Should have table map events for update operations"
+        );
+
         // Verify update events reference the correct table ID
-        let table_event = runner.table_map_events.iter()
-            .find(|event| event.database_name == runner.default_db && event.table_name == runner.default_tb)
+        let table_event = runner
+            .table_map_events
+            .iter()
+            .find(|event| {
+                event.database_name == runner.default_db && event.table_name == runner.default_tb
+            })
             .expect("Should find table map event for default test table");
-        
+
         for update_event in &runner.update_events {
-            assert_eq!(update_event.table_id, table_event.table_id, "Update events should reference the correct table");
+            assert_eq!(
+                update_event.table_id, table_event.table_id,
+                "Update events should reference the correct table"
+            );
         }
 
         // row 0, before

--- a/tests/runner/test_runner.rs
+++ b/tests/runner/test_runner.rs
@@ -12,7 +12,8 @@ pub(crate) mod test {
         command::{authenticator::Authenticator, command_util::CommandUtil},
         event::{
             delete_rows_event::DeleteRowsEvent, event_data::EventData, query_event::QueryEvent,
-            table_map_event::TableMapEvent, update_rows_event::UpdateRowsEvent, write_rows_event::WriteRowsEvent,
+            table_map_event::TableMapEvent, update_rows_event::UpdateRowsEvent,
+            write_rows_event::WriteRowsEvent,
         },
     };
 


### PR DESCRIPTION
Hi @caiq1nyu, this is a follow-up to #30.

It fixes a bug where ENUM and SET column metadata was being applied to the wrong columns. The metadata stream provides ENUM/SET string values only for actual ENUM/SET columns, but the previous implementation incorrectly assumed they was something provided for all columns in order.