### PR TITLE
feat: add optional TLS support for MySQL connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,7 @@ members = [
 [package]
 edition = "2021"
 name = "mysql-binlog-connector-rust"
-version = "0.3.3"
-authors = ["Shicai Xu <chenglingsu@126.com>"]
+version = "0.3.4"
 categories = ["database"]
 description = "mysql binlog connector"
 documentation = "https://docs.rs/mysql-binlog-connector-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ readme = "README.md"
 [features]
 default = []
 rustls = ["dep:futures", "dep:futures-rustls", "dep:rustls"]
+openssl-tls = ["dep:openssl", "dep:async-std-openssl"]
 
 [dependencies]
 byteorder = "1.4.3"
@@ -47,3 +48,5 @@ socket2 = "0.6.1"
 futures = { version = "0.3", optional = true }
 futures-rustls = { version = "0.26", optional = true }
 rustls = { version = "0.23", optional = true }
+openssl = { version = "0.10", optional = true }
+async-std-openssl = { version = "0.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = []
+rustls = ["dep:futures", "dep:futures-rustls", "dep:rustls"]
+
 [dependencies]
 byteorder = "1.4.3"
 num_enum = "0.7.3"
@@ -40,3 +44,6 @@ mysql_common = "0.32.4"
 base64 = "0.22.1"
 log = "0.4.26"
 socket2 = "0.6.1"
+futures = { version = "0.3", optional = true }
+futures-rustls = { version = "0.26", optional = true }
+rustls = { version = "0.23", optional = true }

--- a/README.md
+++ b/README.md
@@ -35,40 +35,41 @@ English | [中文](README_ZH.md)
 - UPDATE_ROWS_EVENT
 - DELETE_ROWS_EVENT_V1
 - DELETE_ROWS_EVENT
-
 - for more details, refer to: [mysql doc](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_replication_binlog_event.html)
 
 ### Mapping between mysql columns and rust types
 
-| mysql column type                                                   | binlog column type(raw)     | binlog column type(parsed from binlog column meta) | rust type                          |
-| :------------------------------------------------------------------ | :-------------------------- | :------------------------------------------------- | :--------------------------------- |
-| BIT                                                                 | MYSQL_TYPE_BIT = 16         | ColumnType::Bit                                    | ColumnValue::Bit(u64)              |
-| TINYINT [UNSIGNED]                                                  | MYSQL_TYPE_TINY = 1         | ColumnType::Tiny                                   | ColumnValue::Tiny(i8)              |
-| SMALLINT [UNSIGNED]                                                 | MYSQL_TYPE_SHORT = 2        | ColumnType::Short                                  | ColumnValue::Short(i16)            |
-| MEDIUMINT [UNSIGNED]                                                | MYSQL_TYPE_INT24 = 9        | ColumnType::Int24                                  | ColumnValue::Long(i32)             |
-| INT [UNSIGNED]                                                      | MYSQL_TYPE_LONG = 3         | ColumnType::Long                                   | ColumnValue::Long(i32)             |
-| BIGINT [UNSIGNED]                                                   | MYSQL_TYPE_LONGLONG = 8     | ColumnType::LongLong                               | ColumnValue::LongLong(i64)         |
-| FLOAT                                                               | MYSQL_TYPE_FLOAT = 4        | ColumnType::Float                                  | ColumnValue::Float(f32)            |
-| DOUBLE                                                              | MYSQL_TYPE_DOUBLE = 5       | ColumnType::Double                                 | ColumnValue::Double(f64)           |
-| DECIMAL                                                             | MYSQL_TYPE_NEWDECIMAL = 246 | ColumnType::NewDecimal                             | ColumnValue::Decimal(String)       |
-| DATE                                                                | MYSQL_TYPE_DATE = 10        | ColumnType::Date                                   | ColumnValue::Date(String)          |
-| TIME                                                                | MYSQL_TYPE_TIME2 = 19       | ColumnType::Time2                                  | ColumnValue::Time(String)          |
-| TIMESTAMP                                                           | MYSQL_TYPE_TIMESTAMP2 = 17  | ColumnType::TimeStamp2                             | ColumnValue::Timestamp(i64)        |
-| DATETIME                                                            | MYSQL_TYPE_DATETIME2 = 18   | ColumnType::DateTime2                              | ColumnValue::DateTime(String)      |
-| YEAR                                                                | MYSQL_TYPE_YEAR = 13        | ColumnType::Year                                   | ColumnValue::Year(u16)             |
-| CHAR                                                                | MYSQL_TYPE_STRING = 254     | ColumnType::String                                 | ColumnValue::String(Vec&lt;u8&gt;) |
-| VARCHAR                                                             | MYSQL_TYPE_VARCHAR = 15     | ColumnType::VarChar                                | ColumnValue::String(Vec&lt;u8&gt;) |
-| BINARY                                                              | MYSQL_TYPE_STRING = 254     | ColumnType::String                                 | ColumnValue::String(Vec&lt;u8&gt;) |
-| VARBINARY                                                           | MYSQL_TYPE_VARCHAR = 15     | ColumnType::VarChar                                | ColumnValue::String(Vec&lt;u8&gt;) |
-| ENUM                                                                | MYSQL_TYPE_STRING = 254     | ColumnType::Enum                                   | ColumnValue::Enum(u32)             |
-| SET                                                                 | MYSQL_TYPE_STRING = 254     | ColumnType::Set                                    | ColumnValue::Set(u64)              |
-| TINYTEXT TEXT MEDIUMTEXT LONGTEXT TINYBLOB BLOB MEDIUMBLOB LONGBLOB | MYSQL_TYPE_BLOB = 252       | ColumnType::Blob                                   | ColumnValue::Blob(Vec&lt;u8&gt;)   |
-| GEOMETRY                                                            | MYSQL_TYPE_GEOMETRY = 255   | ColumnType::Geometry                               | ColumnValue::Blob(Vec&lt;u8&gt;)   |
-| JSON                                                                | MYSQL_TYPE_JSON = 245       | ColumnType::Json                                   | ColumnValue::Json(Vec&lt;u8&gt;)   |
 
-- for CHAR / VARCHAR columns, since binlog contains no charset information, we just get raw bytes and store them in ColumnValue::String(Vec&lt;u8&gt;) objects, you may need to convert them into strings based on column metadatas for further usage.
+| mysql column type                                                   | binlog column type(raw)     | binlog column type(parsed from binlog column meta) | rust type                     |
+| ------------------------------------------------------------------- | --------------------------- | -------------------------------------------------- | ----------------------------- |
+| BIT                                                                 | MYSQL_TYPE_BIT = 16         | ColumnType::Bit                                    | ColumnValue::Bit(u64)         |
+| TINYINT [UNSIGNED]                                                  | MYSQL_TYPE_TINY = 1         | ColumnType::Tiny                                   | ColumnValue::Tiny(i8)         |
+| SMALLINT [UNSIGNED]                                                 | MYSQL_TYPE_SHORT = 2        | ColumnType::Short                                  | ColumnValue::Short(i16)       |
+| MEDIUMINT [UNSIGNED]                                                | MYSQL_TYPE_INT24 = 9        | ColumnType::Int24                                  | ColumnValue::Long(i32)        |
+| INT [UNSIGNED]                                                      | MYSQL_TYPE_LONG = 3         | ColumnType::Long                                   | ColumnValue::Long(i32)        |
+| BIGINT [UNSIGNED]                                                   | MYSQL_TYPE_LONGLONG = 8     | ColumnType::LongLong                               | ColumnValue::LongLong(i64)    |
+| FLOAT                                                               | MYSQL_TYPE_FLOAT = 4        | ColumnType::Float                                  | ColumnValue::Float(f32)       |
+| DOUBLE                                                              | MYSQL_TYPE_DOUBLE = 5       | ColumnType::Double                                 | ColumnValue::Double(f64)      |
+| DECIMAL                                                             | MYSQL_TYPE_NEWDECIMAL = 246 | ColumnType::NewDecimal                             | ColumnValue::Decimal(String)  |
+| DATE                                                                | MYSQL_TYPE_DATE = 10        | ColumnType::Date                                   | ColumnValue::Date(String)     |
+| TIME                                                                | MYSQL_TYPE_TIME2 = 19       | ColumnType::Time2                                  | ColumnValue::Time(String)     |
+| TIMESTAMP                                                           | MYSQL_TYPE_TIMESTAMP2 = 17  | ColumnType::TimeStamp2                             | ColumnValue::Timestamp(i64)   |
+| DATETIME                                                            | MYSQL_TYPE_DATETIME2 = 18   | ColumnType::DateTime2                              | ColumnValue::DateTime(String) |
+| YEAR                                                                | MYSQL_TYPE_YEAR = 13        | ColumnType::Year                                   | ColumnValue::Year(u16)        |
+| CHAR                                                                | MYSQL_TYPE_STRING = 254     | ColumnType::String                                 | ColumnValue::String(Vec)      |
+| VARCHAR                                                             | MYSQL_TYPE_VARCHAR = 15     | ColumnType::VarChar                                | ColumnValue::String(Vec)      |
+| BINARY                                                              | MYSQL_TYPE_STRING = 254     | ColumnType::String                                 | ColumnValue::String(Vec)      |
+| VARBINARY                                                           | MYSQL_TYPE_VARCHAR = 15     | ColumnType::VarChar                                | ColumnValue::String(Vec)      |
+| ENUM                                                                | MYSQL_TYPE_STRING = 254     | ColumnType::Enum                                   | ColumnValue::Enum(u32)        |
+| SET                                                                 | MYSQL_TYPE_STRING = 254     | ColumnType::Set                                    | ColumnValue::Set(u64)         |
+| TINYTEXT TEXT MEDIUMTEXT LONGTEXT TINYBLOB BLOB MEDIUMBLOB LONGBLOB | MYSQL_TYPE_BLOB = 252       | ColumnType::Blob                                   | ColumnValue::Blob(Vec)        |
+| GEOMETRY                                                            | MYSQL_TYPE_GEOMETRY = 255   | ColumnType::Geometry                               | ColumnValue::Blob(Vec)        |
+| JSON                                                                | MYSQL_TYPE_JSON = 245       | ColumnType::Json                                   | ColumnValue::Json(Vec)        |
+
+
+- for CHAR / VARCHAR columns, since binlog contains no charset information, we just get raw bytes and store them in ColumnValue::String(Vec) objects, you may need to convert them into strings based on column metadatas for further usage.
 - for UNSIGNED numeric columns, since binlog contains no unsigned flags, we just parse them as signed numerics, you may need to convert them into unsigned values based on column metadatas for further usage.
-- for JSON columns, we get raw bytes and store them in ColumnValue::Json(Vec&lt;u8&gt;) objects, we also provide a default deserializer "JsonBinary" to parse them into strings, find example later in this doc.
+- for JSON columns, we get raw bytes and store them in ColumnValue::Json(Vec) objects, we also provide a default deserializer "JsonBinary" to parse them into strings, find example later in this doc.
 
 ## Quick start
 
@@ -137,10 +138,41 @@ binlog_parse_millis=100
 cargo test --package mysql-binlog-connector-rust --test integration_test
 ```
 
+- TLS configuration
+- TLS is optional and disabled by default.
+- To require TLS, append `ssl-mode=required` to `db_url`. To use plain TCP, set `ssl-mode=disabled` or omit it.
+- This crate currently supports two TLS backends:
+-   `openssl-tls`: better compatibility with older MySQL 5.7 TLS stacks
+-   `rustls`: pure Rust TLS backend
+- Enable exactly one TLS feature when building:
+
+```
+cargo test --package mysql-binlog-connector-rust --test integration_test --features openssl-tls
+```
+
+or
+
+```
+cargo test --package mysql-binlog-connector-rust --test integration_test --features rustls
+```
+
+- example `db_url` with TLS enabled:
+
+```
+db_url=mysql://root:123456@127.0.0.1:3307?ssl-mode=required
+```
+
+- example `db_url` with TLS disabled:
+
+```
+db_url=mysql://root:123456@127.0.0.1:3307?ssl-mode=disabled
+```
+
+- Note: current TLS implementation skips server certificate verification. It encrypts the transport, but does not verify server identity.
 - each test will:
-- &nbsp; execute sqls to create tables and generate binlogs
-- &nbsp; dump and parse binlogs
-- &nbsp; wait binlog_parse_millis for all binlogs to be parsed
+-   execute sqls to create tables and generate binlogs
+-   dump and parse binlogs
+-   wait binlog_parse_millis for all binlogs to be parsed
 - you may increase binlog_parse_millis for big transactions
 
 ## Examples
@@ -193,6 +225,18 @@ async fn dump_and_parse() {
         println!();
     }
 }
+```
+
+- Run the example with TLS support:
+
+```
+cargo run -p mysql-binlog-connector-rust-example
+```
+
+- The bundled example crate currently enables `openssl-tls` by default. If you want to switch to `rustls`, update `example/Cargo.toml` and set:
+
+```toml
+mysql-binlog-connector-rust = { path = "../", features = ["rustls"] }
 ```
 
 ### Example 1: parse binlogs with binlog-transaction-compression disabled
@@ -477,3 +521,4 @@ async fn parse_file() {
     }
 }
 ```
+

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -137,6 +137,39 @@ binlog_parse_millis=100
 cargo test --package mysql-binlog-connector-rust --test integration_test
 ```
 
+- TLS 配置说明
+
+- TLS 默认关闭，为可选功能。
+- 如果要强制启用 TLS，请在 `db_url` 中追加 `ssl-mode=required`。如果要使用明文 TCP，请设置 `ssl-mode=disabled`，或者省略该参数。
+- 当前支持两种 TLS 后端：
+- &nbsp; `openssl-tls`：对老版本 MySQL 5.7 的 TLS 兼容性更好
+- &nbsp; `rustls`：纯 Rust TLS 实现
+- 编译时只能启用一个 TLS feature：
+
+```
+cargo test --package mysql-binlog-connector-rust --test integration_test --features openssl-tls
+```
+
+或者：
+
+```
+cargo test --package mysql-binlog-connector-rust --test integration_test --features rustls
+```
+
+- 开启 TLS 的 `db_url` 示例：
+
+```
+db_url=mysql://root:123456@127.0.0.1:3307?ssl-mode=required
+```
+
+- 关闭 TLS 的 `db_url` 示例：
+
+```
+db_url=mysql://root:123456@127.0.0.1:3307?ssl-mode=disabled
+```
+
+- 注意：当前 TLS 实现会跳过服务端证书校验。也就是说链路会被加密，但不会校验服务端身份。
+
 - 每个测试用例会：
 - &nbsp; &nbsp; &nbsp; &nbsp; 执行 sql 并生成 binlog
 - &nbsp; &nbsp; &nbsp; &nbsp; 获取 binlog 并解析
@@ -193,6 +226,18 @@ async fn dump_and_parse() {
         println!();
     }
 }
+```
+
+- 使用带 TLS 支持的 example：
+
+```
+cargo run -p mysql-binlog-connector-rust-example
+```
+
+- 当前仓库内置的 example 默认启用了 `openssl-tls`。如果你想切换为 `rustls`，可以修改 `example/Cargo.toml`：
+
+```toml
+mysql-binlog-connector-rust = { path = "../", features = ["rustls"] }
 ```
 
 ### 用例 1: 解析关闭 binlog-transaction-compression 的事务

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 dotenv = "0.15.0"
 futures = "0.3"
-mysql-binlog-connector-rust = { path = "../", features = ["openssl-tls"] }
+mysql-binlog-connector-rust = { path = "../" }
+# mysql-binlog-connector-rust = { path = "../", features = ["openssl-tls"] }
 # mysql-binlog-connector-rust = { path = "../", features = ["rustls"] }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 [dependencies]
 dotenv = "0.15.0"
 futures = "0.3"
-mysql-binlog-connector-rust = { path = "../", features = ["rustls"]}
+mysql-binlog-connector-rust = { path = "../", features = ["openssl-tls"] }
+# mysql-binlog-connector-rust = { path = "../", features = ["rustls"] }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 dotenv = "0.15.0"
 futures = "0.3"
-mysql-binlog-connector-rust = { path = "../" }
+mysql-binlog-connector-rust = { path = "../", features = ["rustls"]}

--- a/example/src/.env
+++ b/example/src/.env
@@ -1,5 +1,5 @@
-db_url=mysql://root:0hSo2jN877@127.0.0.1:13306?ssl-mode=required
+db_url=mysql://root:123456@127.0.0.1:3306
 server_id=200
-binlog_filename=wheat-7899b7dd74-mysql-0-bin.000004
-binlog_position=989651
-gtid_set=018925e3-3d6e-11f1-bbc6-d2f8d56d9189:1-2678
+binlog_filename=mysql-bin.000028
+binlog_position=3550
+gtid_set=96a2b085-c1c8-11ef-8601-0242ac110002:1-31161

--- a/example/src/.env
+++ b/example/src/.env
@@ -1,5 +1,5 @@
-db_url=mysql://root:123456@127.0.0.1:3306
+db_url=mysql://root:0hSo2jN877@127.0.0.1:13306?ssl-mode=required
 server_id=200
-binlog_filename=mysql-bin.000020
-binlog_position=493
-gtid_set=96a2b085-c1c8-11ef-8601-0242ac110002:1-12361
+binlog_filename=wheat-7899b7dd74-mysql-0-bin.000004
+binlog_position=989651
+gtid_set=018925e3-3d6e-11f1-bbc6-d2f8d56d9189:1-2678

--- a/src/command/auth_native_password_command.rs
+++ b/src/command/auth_native_password_command.rs
@@ -13,6 +13,7 @@ pub struct AuthNativePasswordCommand {
     pub password: String,
     pub scramble: String,
     pub collation: u8,
+    pub client_capabilities: u32,
 }
 
 impl AuthNativePasswordCommand {
@@ -24,13 +25,7 @@ impl AuthNativePasswordCommand {
     pub fn to_bytes(&mut self) -> Result<Vec<u8>, BinlogError> {
         let mut buf = Vec::new();
 
-        let mut client_capabilities = ClientCapabilities::LONG_FLAG
-            | ClientCapabilities::PROTOCOL_41
-            | ClientCapabilities::SECURE_CONNECTION
-            | ClientCapabilities::PLUGIN_AUTH;
-        if !self.schema.is_empty() {
-            client_capabilities |= ClientCapabilities::CONNECT_WITH_DB;
-        }
+        let client_capabilities = self.client_capabilities | ClientCapabilities::PLUGIN_AUTH;
         buf.write_u32::<LittleEndian>(client_capabilities)?;
 
         // maximum packet length

--- a/src/command/auth_sha2_password_command.rs
+++ b/src/command/auth_sha2_password_command.rs
@@ -14,6 +14,7 @@ pub struct AuthSha2PasswordCommand {
     pub password: String,
     pub scramble: String,
     pub collation: u8,
+    pub client_capabilities: u32,
 }
 
 impl AuthSha2PasswordCommand {
@@ -25,14 +26,10 @@ impl AuthSha2PasswordCommand {
     pub fn to_bytes(&mut self) -> Result<Vec<u8>, BinlogError> {
         let mut buf = Vec::new();
 
-        let mut client_capabilities = ClientCapabilities::LONG_FLAG
-            | ClientCapabilities::PROTOCOL_41
-            | ClientCapabilities::SECURE_CONNECTION
-            | ClientCapabilities::PLUGIN_AUTH
-            | ClientCapabilities::PLUGIN_AUTH_LENENC_CLIENT_DATA;
-        if !self.schema.is_empty() {
-            client_capabilities |= ClientCapabilities::CONNECT_WITH_DB;
-        }
+        // Use the Protocol::HandshakeResponse41 secure-connection auth format.
+        // We intentionally do not advertise PLUGIN_AUTH_LENENC_CLIENT_DATA because
+        // this command writes the auth response with a 1-byte length prefix.
+        let client_capabilities = self.client_capabilities | ClientCapabilities::PLUGIN_AUTH;
         buf.write_u32::<LittleEndian>(client_capabilities)?;
 
         // maximum packet length

--- a/src/command/authenticator.rs
+++ b/src/command/authenticator.rs
@@ -4,7 +4,7 @@ use url::Url;
 
 use crate::{
     binlog_error::BinlogError,
-    constants::MysqlRespCode,
+    constants::{ClientCapabilities, MysqlRespCode, NULL_TERMINATOR},
     network::{
         auth_plugin_switch_packet::AuthPluginSwitchPacket,
         greeting_packet::GreetingPacket,
@@ -16,7 +16,32 @@ use super::{
     auth_native_password_command::AuthNativePasswordCommand, auth_plugin::AuthPlugin,
     auth_sha2_password_command::AuthSha2PasswordCommand,
     auth_sha2_rsa_password_command::AuthSha2RsaPasswordCommand, command_util::CommandUtil,
+    ssl_request_command::SSLRequestCommand,
 };
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TlsMode {
+    Disabled,
+    Required,
+}
+
+impl TlsMode {
+    fn from_url(url: &Url) -> Result<Self, BinlogError> {
+        let ssl_mode = url
+            .query_pairs()
+            .find_map(|(key, value)| (key == "ssl-mode").then_some(value.into_owned()))
+            .unwrap_or_else(|| "disabled".into());
+
+        match ssl_mode.to_ascii_lowercase().as_str() {
+            "disabled" => Ok(Self::Disabled),
+            "required" => Ok(Self::Required),
+            other => Err(BinlogError::ConnectError(format!(
+                "unsupported ssl-mode: {}",
+                other
+            ))),
+        }
+    }
+}
 
 pub struct Authenticator {
     host: String,
@@ -28,6 +53,7 @@ pub struct Authenticator {
     collation: u8,
     timeout_secs: u64,
     keepalive_config: Option<KeepAliveConfig>,
+    tls_mode: TlsMode,
 }
 
 impl Authenticator {
@@ -50,6 +76,14 @@ impl Authenticator {
             }
         }
 
+        let tls_mode = TlsMode::from_url(&url_info)?;
+        if tls_mode == TlsMode::Required && !cfg!(feature = "rustls") {
+            return Err(BinlogError::ConnectError(
+                "TLS requested via ssl-mode=required, but crate was built without the 'rustls' feature"
+                    .into(),
+            ));
+        }
+
         Ok(Self {
             host: percent_decode_str(host).decode_utf8_lossy().to_string(),
             port,
@@ -60,11 +94,11 @@ impl Authenticator {
             collation: 0,
             timeout_secs,
             keepalive_config,
+            tls_mode,
         })
     }
 
     pub async fn connect(&mut self) -> Result<PacketChannel, BinlogError> {
-        // connect to hostname:port
         let mut channel = PacketChannel::new(
             &self.host,
             &self.port,
@@ -73,22 +107,67 @@ impl Authenticator {
         )
         .await?;
 
-        // read and parse greeting packet
-        let (greeting_buf, sequence) = channel.read_with_sequece().await?;
+        let (greeting_buf, greeting_sequence) = channel.read_with_sequece().await?;
         let greeting_packet = GreetingPacket::new(greeting_buf)?;
 
         self.collation = greeting_packet.server_collation;
         self.scramble = greeting_packet.scramble;
 
-        // authenticate
+        let mut next_sequence = greeting_sequence + 1;
+        if self.tls_mode == TlsMode::Required {
+            if greeting_packet.server_capabilities & ClientCapabilities::SSL as u16 == 0 {
+                return Err(BinlogError::ConnectError(
+                    "mysql server does not support tls".into(),
+                ));
+            }
+
+            let ssl_request = SSLRequestCommand {
+                client_capabilities: self.client_capabilities_for_plugin(
+                    &greeting_packet.plugin_provided_data,
+                ),
+                collation: self.collation,
+            };
+            channel
+                .write(&ssl_request.to_bytes()?, next_sequence)
+                .await?;
+            channel.upgrade_to_tls(&self.host).await?;
+            next_sequence += 1;
+        }
+
         self.authenticate(
             &mut channel,
             &greeting_packet.plugin_provided_data,
-            sequence,
+            next_sequence,
         )
         .await?;
 
         Ok(channel)
+    }
+
+    fn base_client_capabilities(&self) -> u32 {
+        let mut client_capabilities = ClientCapabilities::LONG_FLAG
+            | ClientCapabilities::LONG_PASSWORD
+            | ClientCapabilities::PROTOCOL_41
+            | ClientCapabilities::TRANSACTIONS
+            | ClientCapabilities::SECURE_CONNECTION;
+        if !self.schema.is_empty() {
+            client_capabilities |= ClientCapabilities::CONNECT_WITH_DB;
+        }
+        client_capabilities
+    }
+
+    fn client_capabilities_for_plugin(&self, auth_plugin_name: &str) -> u32 {
+        let mut client_capabilities = self.base_client_capabilities();
+        match AuthPlugin::from_name(auth_plugin_name) {
+            AuthPlugin::MySqlNativePassword => {
+                client_capabilities |= ClientCapabilities::PLUGIN_AUTH;
+            }
+            AuthPlugin::CachingSha2Password => {
+                client_capabilities |= ClientCapabilities::PLUGIN_AUTH;
+            }
+            AuthPlugin::Unsupported => {}
+        }
+        client_capabilities
     }
 
     async fn authenticate(
@@ -97,6 +176,7 @@ impl Authenticator {
         auth_plugin_name: &str,
         sequence: u8,
     ) -> Result<(), BinlogError> {
+        let client_capabilities = self.client_capabilities_for_plugin(auth_plugin_name);
         let command_buf = match AuthPlugin::from_name(auth_plugin_name) {
             AuthPlugin::MySqlNativePassword => AuthNativePasswordCommand {
                 schema: self.schema.clone(),
@@ -104,6 +184,7 @@ impl Authenticator {
                 password: self.password.clone(),
                 scramble: self.scramble.clone(),
                 collation: self.collation,
+                client_capabilities,
             }
             .to_bytes()?,
 
@@ -113,6 +194,7 @@ impl Authenticator {
                 password: self.password.clone(),
                 scramble: self.scramble.clone(),
                 collation: self.collation,
+                client_capabilities,
             }
             .to_bytes()?,
 
@@ -121,7 +203,7 @@ impl Authenticator {
             }
         };
 
-        channel.write(&command_buf, sequence + 1).await?;
+        channel.write(&command_buf, sequence).await?;
         let (auth_res, sequence) = channel.read_with_sequece().await?;
         self.handle_auth_result(channel, auth_plugin_name, sequence, &auth_res)
             .await
@@ -134,18 +216,14 @@ impl Authenticator {
         sequence: u8,
         auth_res: &Vec<u8>,
     ) -> Result<(), BinlogError> {
-        // parse result
         match auth_res[0] {
             MysqlRespCode::OK => return Ok(()),
-
             MysqlRespCode::ERROR => return CommandUtil::check_error_packet(auth_res),
-
             MysqlRespCode::AUTH_PLUGIN_SWITCH => {
                 return self
                     .handle_auth_plugin_switch(channel, sequence, auth_res)
                     .await;
             }
-
             _ => match AuthPlugin::from_name(auth_plugin_name) {
                 AuthPlugin::MySqlNativePassword => {
                     return Err(BinlogError::ConnectError(format!(
@@ -153,15 +231,12 @@ impl Authenticator {
                         auth_res[0]
                     )));
                 }
-
                 AuthPlugin::CachingSha2Password => {
                     return self
                         .handle_sha2_auth_result(channel, sequence, auth_res)
                         .await;
                 }
-
-                // won't happen
-                _ => {}
+                AuthPlugin::Unsupported => {}
             },
         };
 
@@ -186,6 +261,7 @@ impl Authenticator {
                 password: self.password.clone(),
                 scramble: self.scramble.clone(),
                 collation: self.collation,
+                client_capabilities: self.base_client_capabilities(),
             }
             .encrypted_password()?,
 
@@ -195,6 +271,7 @@ impl Authenticator {
                 password: self.password.clone(),
                 scramble: self.scramble.clone(),
                 collation: self.collation,
+                client_capabilities: self.base_client_capabilities(),
             }
             .encrypted_password()?,
 
@@ -218,12 +295,18 @@ impl Authenticator {
         sequence: u8,
         auth_res: &[u8],
     ) -> Result<(), BinlogError> {
-        // buf[0] is the length of buf, always 1
+        if auth_res.len() < 2 {
+            return Err(BinlogError::ConnectError(
+                "unexpected short auth result for caching_sha2_password".into(),
+            ));
+        }
+
         match auth_res[1] {
             0x03 => Ok(()),
-
+            0x04 if channel.is_secure_transport() => {
+                self.sha2_secure_authenticate(channel, sequence).await
+            }
             0x04 => self.sha2_rsa_authenticate(channel, sequence).await,
-
             _ => Err(BinlogError::ConnectError(format!(
                 "unexpected auth result for caching_sha2_password: {}",
                 auth_res[1]
@@ -231,18 +314,28 @@ impl Authenticator {
         }
     }
 
+    async fn sha2_secure_authenticate(
+        &self,
+        channel: &mut PacketChannel,
+        sequence: u8,
+    ) -> Result<(), BinlogError> {
+        let mut password = self.password.as_bytes().to_vec();
+        password.push(NULL_TERMINATOR);
+        channel.write(&password, sequence + 1).await?;
+
+        let (auth_res, _) = channel.read_with_sequece().await?;
+        CommandUtil::parse_result(&auth_res)
+    }
+
     async fn sha2_rsa_authenticate(
         &self,
         channel: &mut PacketChannel,
         sequence: u8,
     ) -> Result<(), BinlogError> {
-        // refer: https://mariadb.com/kb/en/caching_sha2_password-authentication-plugin/
-        // try to get RSA key from server
         channel.write(&[0x02], sequence + 1).await?;
         let (rsa_res, sequence) = channel.read_with_sequece().await?;
         match rsa_res[0] {
             0x01 => {
-                // try sha2 authentication with rsa
                 let mut command = AuthSha2RsaPasswordCommand {
                     rsa_res: rsa_res[1..].to_vec(),
                     password: self.password.clone(),
@@ -259,5 +352,58 @@ impl Authenticator {
                 rsa_res[0]
             ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Authenticator, TlsMode};
+
+    #[test]
+    fn parses_default_ssl_mode_as_disabled() {
+        let auth = Authenticator::new("mysql://root:pwd@127.0.0.1:3306/test", 3, None).unwrap();
+        assert_eq!(auth.tls_mode, TlsMode::Disabled);
+    }
+
+    #[test]
+    fn rejects_unsupported_ssl_mode() {
+        let err = Authenticator::new(
+            "mysql://root:pwd@127.0.0.1:3306/test?ssl-mode=preferred",
+            3,
+            None,
+        )
+        .err()
+        .unwrap();
+
+        assert!(err.to_string().contains("unsupported ssl-mode"));
+    }
+
+    #[cfg(not(feature = "rustls"))]
+    #[test]
+    fn rejects_required_tls_without_rustls_feature() {
+        let err = Authenticator::new(
+            "mysql://root:pwd@127.0.0.1:3306/test?ssl-mode=required",
+            3,
+            None,
+        )
+        .err()
+        .unwrap();
+
+        assert!(err
+            .to_string()
+            .contains("built without the 'rustls' feature"));
+    }
+
+    #[cfg(feature = "rustls")]
+    #[test]
+    fn accepts_required_tls_with_rustls_feature() {
+        let auth = Authenticator::new(
+            "mysql://root:pwd@127.0.0.1:3306/test?ssl-mode=required",
+            3,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(auth.tls_mode, TlsMode::Required);
     }
 }

--- a/src/command/authenticator.rs
+++ b/src/command/authenticator.rs
@@ -77,9 +77,11 @@ impl Authenticator {
         }
 
         let tls_mode = TlsMode::from_url(&url_info)?;
-        if tls_mode == TlsMode::Required && !cfg!(feature = "rustls") {
+        if tls_mode == TlsMode::Required
+            && !cfg!(any(feature = "rustls", feature = "openssl-tls"))
+        {
             return Err(BinlogError::ConnectError(
-                "TLS requested via ssl-mode=required, but crate was built without the 'rustls' feature"
+                "TLS requested via ssl-mode=required, but crate was built without a TLS feature"
                     .into(),
             ));
         }
@@ -378,9 +380,9 @@ mod tests {
         assert!(err.to_string().contains("unsupported ssl-mode"));
     }
 
-    #[cfg(not(feature = "rustls"))]
+    #[cfg(not(any(feature = "rustls", feature = "openssl-tls")))]
     #[test]
-    fn rejects_required_tls_without_rustls_feature() {
+    fn rejects_required_tls_without_tls_feature() {
         let err = Authenticator::new(
             "mysql://root:pwd@127.0.0.1:3306/test?ssl-mode=required",
             3,
@@ -391,12 +393,12 @@ mod tests {
 
         assert!(err
             .to_string()
-            .contains("built without the 'rustls' feature"));
+            .contains("built without a TLS feature"));
     }
 
-    #[cfg(feature = "rustls")]
+    #[cfg(any(feature = "rustls", feature = "openssl-tls"))]
     #[test]
-    fn accepts_required_tls_with_rustls_feature() {
+    fn accepts_required_tls_with_tls_feature() {
         let auth = Authenticator::new(
             "mysql://root:pwd@127.0.0.1:3306/test?ssl-mode=required",
             3,
@@ -406,4 +408,5 @@ mod tests {
 
         assert_eq!(auth.tls_mode, TlsMode::Required);
     }
+
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -9,3 +9,4 @@ pub mod dump_binlog_command;
 pub mod dump_binlog_gtid_command;
 pub mod gtid_set;
 pub mod query_command;
+pub mod ssl_request_command;

--- a/src/command/ssl_request_command.rs
+++ b/src/command/ssl_request_command.rs
@@ -1,0 +1,51 @@
+use byteorder::{LittleEndian, WriteBytesExt};
+
+use crate::{binlog_error::BinlogError, constants::ClientCapabilities};
+
+pub struct SSLRequestCommand {
+    pub client_capabilities: u32,
+    pub collation: u8,
+}
+
+impl SSLRequestCommand {
+    pub fn to_bytes(&self) -> Result<Vec<u8>, BinlogError> {
+        let mut buf = Vec::new();
+        let client_capabilities = self.client_capabilities | ClientCapabilities::SSL;
+
+        buf.write_u32::<LittleEndian>(client_capabilities)?;
+        buf.write_u32::<LittleEndian>(0)?;
+        buf.write_u8(self.collation)?;
+
+        for _ in 0..23 {
+            buf.write_u8(0)?;
+        }
+
+        Ok(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::constants::ClientCapabilities;
+
+    use super::SSLRequestCommand;
+
+    #[test]
+    fn ssl_request_sets_ssl_capability() {
+        let bytes = SSLRequestCommand {
+            client_capabilities: ClientCapabilities::LONG_FLAG
+                | ClientCapabilities::PROTOCOL_41
+                | ClientCapabilities::SECURE_CONNECTION,
+            collation: 45,
+        }
+        .to_bytes()
+        .unwrap();
+
+        assert_eq!(bytes.len(), 32);
+        assert_eq!(
+            u32::from_le_bytes(bytes[0..4].try_into().unwrap()) & ClientCapabilities::SSL,
+            ClientCapabilities::SSL
+        );
+        assert_eq!(bytes[8], 45);
+    }
+}

--- a/src/command/ssl_request_command.rs
+++ b/src/command/ssl_request_command.rs
@@ -2,6 +2,8 @@ use byteorder::{LittleEndian, WriteBytesExt};
 
 use crate::{binlog_error::BinlogError, constants::ClientCapabilities};
 
+const MAX_PACKET_SIZE: u32 = 16_777_215;
+
 pub struct SSLRequestCommand {
     pub client_capabilities: u32,
     pub collation: u8,
@@ -13,7 +15,7 @@ impl SSLRequestCommand {
         let client_capabilities = self.client_capabilities | ClientCapabilities::SSL;
 
         buf.write_u32::<LittleEndian>(client_capabilities)?;
-        buf.write_u32::<LittleEndian>(0)?;
+        buf.write_u32::<LittleEndian>(MAX_PACKET_SIZE)?;
         buf.write_u8(self.collation)?;
 
         for _ in 0..23 {
@@ -28,7 +30,7 @@ impl SSLRequestCommand {
 mod tests {
     use crate::constants::ClientCapabilities;
 
-    use super::SSLRequestCommand;
+    use super::{SSLRequestCommand, MAX_PACKET_SIZE};
 
     #[test]
     fn ssl_request_sets_ssl_capability() {
@@ -47,5 +49,17 @@ mod tests {
             ClientCapabilities::SSL
         );
         assert_eq!(bytes[8], 45);
+    }
+
+    #[test]
+    fn ssl_request_uses_max_packet_size() {
+        let bytes = SSLRequestCommand {
+            client_capabilities: ClientCapabilities::LONG_FLAG,
+            collation: 45,
+        }
+        .to_bytes()
+        .unwrap();
+
+        assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), MAX_PACKET_SIZE);
     }
 }

--- a/src/network/packet_channel.rs
+++ b/src/network/packet_channel.rs
@@ -7,23 +7,105 @@ use std::{
     io::{Cursor, Write},
     time::Duration,
 };
+#[cfg(feature = "rustls")]
+use std::net::IpAddr;
 
-use async_std::{future::timeout, net::TcpStream, prelude::*};
+use async_std::{
+    future::timeout,
+    io::{ReadExt as AsyncStdReadExt, WriteExt as AsyncStdWriteExt},
+    net::TcpStream,
+};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use log::{trace, warn};
 
 use crate::binlog_error::BinlogError;
 
+#[cfg(feature = "rustls")]
+use futures::io::{AsyncReadExt, AsyncWriteExt};
+#[cfg(feature = "rustls")]
+use futures_rustls::client::TlsStream;
+#[cfg(feature = "rustls")]
+use futures_rustls::TlsConnector;
+#[cfg(feature = "rustls")]
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+#[cfg(feature = "rustls")]
+use rustls::{
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    ClientConfig, DigitallySignedStruct, SignatureScheme,
+};
+#[cfg(feature = "rustls")]
+use std::sync::Arc;
+
 const MAX_PACKET_LENGTH: usize = 16777215;
 
+enum ChannelStream {
+    Plain(TcpStream),
+    #[cfg(feature = "rustls")]
+    Tls(Box<TlsStream<TcpStream>>),
+}
+
 pub struct PacketChannel {
-    stream: TcpStream,
+    stream: Option<ChannelStream>,
     timeout_secs: u64,
 }
 
 pub struct KeepAliveConfig {
     pub keepidle_secs: u64,
     pub keepintvl_secs: u64,
+}
+
+#[cfg(feature = "rustls")]
+#[derive(Debug)]
+struct NoCertificateVerification;
+
+#[cfg(feature = "rustls")]
+impl ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA1,
+            SignatureScheme::ECDSA_SHA1_Legacy,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+            SignatureScheme::ED448,
+        ]
+    }
 }
 
 impl PacketChannel {
@@ -51,7 +133,7 @@ impl PacketChannel {
         }
 
         Ok(Self {
-            stream,
+            stream: Some(ChannelStream::Plain(stream)),
             timeout_secs,
         })
     }
@@ -102,14 +184,79 @@ impl PacketChannel {
 
             socket_ref
                 .set_tcp_keepalive(&keepalive)
-                .map_err(|e| BinlogError::IoError(e))?;
+                .map_err(BinlogError::IoError)?;
         }
 
         Ok(())
     }
 
-    pub async fn close(&self) -> Result<(), BinlogError> {
-        self.stream.shutdown(std::net::Shutdown::Both)?;
+    pub fn is_secure_transport(&self) -> bool {
+        match self.stream.as_ref() {
+            Some(ChannelStream::Plain(_)) => false,
+            #[cfg(feature = "rustls")]
+            Some(ChannelStream::Tls(_)) => true,
+            None => false,
+        }
+    }
+
+    #[cfg(feature = "rustls")]
+    pub async fn upgrade_to_tls(&mut self, host: &str) -> Result<(), BinlogError> {
+        let plain_stream = match self.stream.take() {
+            Some(ChannelStream::Plain(stream)) => stream,
+            Some(ChannelStream::Tls(stream)) => {
+                self.stream = Some(ChannelStream::Tls(stream));
+                return Ok(());
+            }
+            None => {
+                return Err(BinlogError::ConnectError(
+                    "cannot upgrade a disconnected channel to tls".into(),
+                ))
+            }
+        };
+
+        let server_name = Self::build_server_name(host)?;
+        let config = ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
+            .with_no_client_auth();
+        let connector = TlsConnector::from(Arc::new(config));
+        let tls_stream = connector
+            .connect(server_name, plain_stream)
+            .await
+            .map_err(|e| BinlogError::ConnectError(format!("tls handshake failed: {}", e)))?;
+
+        self.stream = Some(ChannelStream::Tls(Box::new(tls_stream)));
+        Ok(())
+    }
+
+    #[cfg(feature = "rustls")]
+    fn build_server_name(host: &str) -> Result<ServerName<'static>, BinlogError> {
+        if let Ok(ip_addr) = host.parse::<IpAddr>() {
+            return Ok(ServerName::IpAddress(ip_addr.into()));
+        }
+
+        ServerName::try_from(host.to_string())
+            .map_err(|_| BinlogError::ConnectError(format!("invalid tls server name: {}", host)))
+    }
+
+    #[cfg(not(feature = "rustls"))]
+    pub async fn upgrade_to_tls(&mut self, _host: &str) -> Result<(), BinlogError> {
+        Err(BinlogError::ConnectError(
+            "TLS support is unavailable because the 'rustls' feature is disabled".into(),
+        ))
+    }
+
+    pub async fn close(&mut self) -> Result<(), BinlogError> {
+        match self.stream.as_mut() {
+            Some(ChannelStream::Plain(stream)) => {
+                stream.shutdown(std::net::Shutdown::Both)?;
+            }
+            #[cfg(feature = "rustls")]
+            Some(ChannelStream::Tls(stream)) => {
+                AsyncWriteExt::close(stream.as_mut()).await?;
+            }
+            None => {}
+        }
         Ok(())
     }
 
@@ -118,7 +265,7 @@ impl PacketChannel {
         wtr.write_u24::<LittleEndian>(buf.len() as u32)?;
         wtr.write_u8(sequence)?;
         Write::write(&mut wtr, buf)?;
-        self.stream.write_all(&wtr).await?;
+        self.write_all(&wtr).await?;
         Ok(())
     }
 
@@ -126,12 +273,12 @@ impl PacketChannel {
         let mut buf = vec![0u8; 4];
         match timeout(
             Duration::from_secs(self.timeout_secs),
-            self.stream.read_exact(&mut buf),
+            self.read_exact_into(&mut buf),
         )
         .await
         {
-            Ok(Ok(_)) => {}
-            Ok(Err(e)) => return Err(BinlogError::from(e)),
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e),
             Err(_) => {
                 return Err(BinlogError::UnexpectedData(format!(
                     "Read binlog header timeout after {}s while waiting for packet header",
@@ -172,8 +319,16 @@ impl PacketChannel {
 
     async fn read_exact(&mut self, length: usize) -> Result<Vec<u8>, BinlogError> {
         let mut buf = vec![0u8; length];
-        // keep reading data until the complete packet is received
-        // MySQL protocol packets may require multiple reads for complete reception
+        self.read_loop(&mut buf).await?;
+        Ok(buf)
+    }
+
+    async fn read_exact_into(&mut self, buf: &mut [u8]) -> Result<(), BinlogError> {
+        self.read_loop(buf).await
+    }
+
+    async fn read_loop(&mut self, buf: &mut [u8]) -> Result<(), BinlogError> {
+        let length = buf.len();
         let wait_data_millis = 10;
         let max_zero_reads = self.timeout_secs * 1000 / wait_data_millis;
         let mut read_count = 0;
@@ -182,7 +337,7 @@ impl PacketChannel {
         while read_count < length {
             match timeout(
                 Duration::from_secs(self.timeout_secs),
-                self.stream.read(&mut buf[read_count..]),
+                self.read_once(&mut buf[read_count..]),
             )
             .await
             {
@@ -210,9 +365,7 @@ impl PacketChannel {
                         read_count
                     );
                 }
-                Ok(Err(e)) => {
-                    return Err(BinlogError::from(e));
-                }
+                Ok(Err(e)) => return Err(e),
                 Err(_) => {
                     return Err(BinlogError::UnexpectedData(format!(
                         "Read binlog timeout, expect data length: {}, read so far: {}",
@@ -221,6 +374,59 @@ impl PacketChannel {
                 }
             }
         }
-        Ok(buf)
+        Ok(())
+    }
+
+    async fn write_all(&mut self, buf: &[u8]) -> Result<(), BinlogError> {
+        match &mut self.stream {
+            Some(ChannelStream::Plain(stream)) => {
+                AsyncStdWriteExt::write_all(stream, buf).await?;
+                AsyncStdWriteExt::flush(stream).await?;
+            }
+            #[cfg(feature = "rustls")]
+            Some(ChannelStream::Tls(stream)) => {
+                AsyncWriteExt::write_all(stream.as_mut(), buf).await?;
+                AsyncWriteExt::flush(stream.as_mut()).await?;
+            }
+            None => {
+                return Err(BinlogError::ConnectError(
+                    "channel stream is unavailable".into(),
+                ))
+            }
+        }
+        Ok(())
+    }
+
+    async fn read_once(&mut self, buf: &mut [u8]) -> Result<usize, BinlogError> {
+        let read = match self.stream.as_mut() {
+            Some(ChannelStream::Plain(stream)) => AsyncStdReadExt::read(stream, buf).await?,
+            #[cfg(feature = "rustls")]
+            Some(ChannelStream::Tls(stream)) => AsyncReadExt::read(stream.as_mut(), buf).await?,
+            None => {
+                return Err(BinlogError::ConnectError(
+                    "channel stream is unavailable".into(),
+                ))
+            }
+        };
+        Ok(read)
+    }
+}
+
+#[cfg(all(test, feature = "rustls"))]
+mod tests {
+    use rustls::pki_types::ServerName;
+
+    use super::PacketChannel;
+
+    #[test]
+    fn build_server_name_accepts_ipv4_literals() {
+        let server_name = PacketChannel::build_server_name("127.0.0.1").unwrap();
+        assert!(matches!(server_name, ServerName::IpAddress(_)));
+    }
+
+    #[test]
+    fn build_server_name_accepts_dns_names() {
+        let server_name = PacketChannel::build_server_name("mysql.example.com").unwrap();
+        assert!(matches!(server_name, ServerName::DnsName(_)));
     }
 }

--- a/src/network/packet_channel.rs
+++ b/src/network/packet_channel.rs
@@ -3,12 +3,15 @@ use std::os::unix::io::AsRawFd;
 #[cfg(windows)]
 use std::os::windows::io::AsRawSocket;
 
+#[cfg(all(feature = "rustls", feature = "openssl-tls"))]
+compile_error!("features 'rustls' and 'openssl-tls' are mutually exclusive");
+
+#[cfg(feature = "rustls")]
+use std::net::IpAddr;
 use std::{
     io::{Cursor, Write},
     time::Duration,
 };
-#[cfg(feature = "rustls")]
-use std::net::IpAddr;
 
 use async_std::{
     future::timeout,
@@ -20,12 +23,16 @@ use log::{trace, warn};
 
 use crate::binlog_error::BinlogError;
 
+#[cfg(feature = "openssl-tls")]
+use async_std_openssl::SslStream as OpenSslStream;
 #[cfg(feature = "rustls")]
 use futures::io::{AsyncReadExt, AsyncWriteExt};
 #[cfg(feature = "rustls")]
 use futures_rustls::client::TlsStream;
 #[cfg(feature = "rustls")]
 use futures_rustls::TlsConnector;
+#[cfg(feature = "openssl-tls")]
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 #[cfg(feature = "rustls")]
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 #[cfg(feature = "rustls")]
@@ -41,7 +48,9 @@ const MAX_PACKET_LENGTH: usize = 16777215;
 enum ChannelStream {
     Plain(TcpStream),
     #[cfg(feature = "rustls")]
-    Tls(Box<TlsStream<TcpStream>>),
+    TlsRustls(Box<TlsStream<TcpStream>>),
+    #[cfg(feature = "openssl-tls")]
+    TlsOpenSsl(Box<OpenSslStream<TcpStream>>),
 }
 
 pub struct PacketChannel {
@@ -194,7 +203,9 @@ impl PacketChannel {
         match self.stream.as_ref() {
             Some(ChannelStream::Plain(_)) => false,
             #[cfg(feature = "rustls")]
-            Some(ChannelStream::Tls(_)) => true,
+            Some(ChannelStream::TlsRustls(_)) => true,
+            #[cfg(feature = "openssl-tls")]
+            Some(ChannelStream::TlsOpenSsl(_)) => true,
             None => false,
         }
     }
@@ -203,8 +214,13 @@ impl PacketChannel {
     pub async fn upgrade_to_tls(&mut self, host: &str) -> Result<(), BinlogError> {
         let plain_stream = match self.stream.take() {
             Some(ChannelStream::Plain(stream)) => stream,
-            Some(ChannelStream::Tls(stream)) => {
-                self.stream = Some(ChannelStream::Tls(stream));
+            Some(ChannelStream::TlsRustls(stream)) => {
+                self.stream = Some(ChannelStream::TlsRustls(stream));
+                return Ok(());
+            }
+            #[cfg(feature = "openssl-tls")]
+            Some(ChannelStream::TlsOpenSsl(stream)) => {
+                self.stream = Some(ChannelStream::TlsOpenSsl(stream));
                 return Ok(());
             }
             None => {
@@ -225,7 +241,7 @@ impl PacketChannel {
             .await
             .map_err(|e| BinlogError::ConnectError(format!("tls handshake failed: {}", e)))?;
 
-        self.stream = Some(ChannelStream::Tls(Box::new(tls_stream)));
+        self.stream = Some(ChannelStream::TlsRustls(Box::new(tls_stream)));
         Ok(())
     }
 
@@ -240,9 +256,59 @@ impl PacketChannel {
     }
 
     #[cfg(not(feature = "rustls"))]
+    #[cfg(feature = "openssl-tls")]
+    pub async fn upgrade_to_tls(&mut self, host: &str) -> Result<(), BinlogError> {
+        let plain_stream = match self.stream.take() {
+            Some(ChannelStream::Plain(stream)) => stream,
+            #[cfg(feature = "rustls")]
+            Some(ChannelStream::TlsRustls(stream)) => {
+                self.stream = Some(ChannelStream::TlsRustls(stream));
+                return Ok(());
+            }
+            Some(ChannelStream::TlsOpenSsl(stream)) => {
+                self.stream = Some(ChannelStream::TlsOpenSsl(stream));
+                return Ok(());
+            }
+            None => {
+                return Err(BinlogError::ConnectError(
+                    "cannot upgrade a disconnected channel to tls".into(),
+                ))
+            }
+        };
+
+        let mut builder = SslConnector::builder(SslMethod::tls_client()).map_err(|e| {
+            BinlogError::ConnectError(format!("failed to build openssl connector: {}", e))
+        })?;
+        builder.set_verify(SslVerifyMode::NONE);
+
+        let ssl = builder
+            .build()
+            .configure()
+            .map_err(|e| {
+                BinlogError::ConnectError(format!("failed to configure openssl connector: {}", e))
+            })?
+            .into_ssl(host)
+            .map_err(|e| {
+                BinlogError::ConnectError(format!("failed to prepare openssl session: {}", e))
+            })?;
+
+        let mut tls_stream = OpenSslStream::new(ssl, plain_stream).map_err(|e| {
+            BinlogError::ConnectError(format!("failed to create openssl stream: {}", e))
+        })?;
+        AsyncStdWriteExt::flush(&mut tls_stream).await?;
+        std::pin::Pin::new(&mut tls_stream)
+            .connect()
+            .await
+            .map_err(|e| BinlogError::ConnectError(format!("tls handshake failed: {}", e)))?;
+
+        self.stream = Some(ChannelStream::TlsOpenSsl(Box::new(tls_stream)));
+        Ok(())
+    }
+
+    #[cfg(not(any(feature = "rustls", feature = "openssl-tls")))]
     pub async fn upgrade_to_tls(&mut self, _host: &str) -> Result<(), BinlogError> {
         Err(BinlogError::ConnectError(
-            "TLS support is unavailable because the 'rustls' feature is disabled".into(),
+            "TLS support is unavailable because no TLS feature is enabled".into(),
         ))
     }
 
@@ -252,8 +318,12 @@ impl PacketChannel {
                 stream.shutdown(std::net::Shutdown::Both)?;
             }
             #[cfg(feature = "rustls")]
-            Some(ChannelStream::Tls(stream)) => {
+            Some(ChannelStream::TlsRustls(stream)) => {
                 AsyncWriteExt::close(stream.as_mut()).await?;
+            }
+            #[cfg(feature = "openssl-tls")]
+            Some(ChannelStream::TlsOpenSsl(stream)) => {
+                stream.get_mut().shutdown(std::net::Shutdown::Both)?;
             }
             None => {}
         }
@@ -384,9 +454,14 @@ impl PacketChannel {
                 AsyncStdWriteExt::flush(stream).await?;
             }
             #[cfg(feature = "rustls")]
-            Some(ChannelStream::Tls(stream)) => {
+            Some(ChannelStream::TlsRustls(stream)) => {
                 AsyncWriteExt::write_all(stream.as_mut(), buf).await?;
                 AsyncWriteExt::flush(stream.as_mut()).await?;
+            }
+            #[cfg(feature = "openssl-tls")]
+            Some(ChannelStream::TlsOpenSsl(stream)) => {
+                AsyncStdWriteExt::write_all(stream.as_mut(), buf).await?;
+                AsyncStdWriteExt::flush(stream.as_mut()).await?;
             }
             None => {
                 return Err(BinlogError::ConnectError(
@@ -401,7 +476,13 @@ impl PacketChannel {
         let read = match self.stream.as_mut() {
             Some(ChannelStream::Plain(stream)) => AsyncStdReadExt::read(stream, buf).await?,
             #[cfg(feature = "rustls")]
-            Some(ChannelStream::Tls(stream)) => AsyncReadExt::read(stream.as_mut(), buf).await?,
+            Some(ChannelStream::TlsRustls(stream)) => {
+                AsyncReadExt::read(stream.as_mut(), buf).await?
+            }
+            #[cfg(feature = "openssl-tls")]
+            Some(ChannelStream::TlsOpenSsl(stream)) => {
+                AsyncStdReadExt::read(stream.as_mut(), buf).await?
+            }
             None => {
                 return Err(BinlogError::ConnectError(
                     "channel stream is unavailable".into(),


### PR DESCRIPTION
This PR introduces feature-gated TLS backends (rustls and openssl-tls), enables TLS only when ssl-mode=required is set in the connection URL, and keeps the non-TLS runtime path unchanged. 